### PR TITLE
Trailing whitespace police was here.

### DIFF
--- a/jsdocs.py
+++ b/jsdocs.py
@@ -65,8 +65,8 @@ class JsdocsCommand(sublime_plugin.TextCommand):
         settings = v.settings()
         point = v.sel()[0].end()
 
-        indentSpaces = max(0, settings.get("jsdocs_indentation_spaces", 1))
-        prefix = "*" + (" " * indentSpaces)
+        indentSpaces = " " * max(0, settings.get("jsdocs_indentation_spaces", 1))
+        prefix = "*"
 
         alignTags = settings.get("jsdocs_align_tags", 'deep')
         deepAlignTags = alignTags == 'deep'
@@ -148,7 +148,7 @@ class JsdocsCommand(sublime_plugin.TextCommand):
             else:
                 write(v, " $0 */")
         else:
-            snippet = "\n " + prefix
+            snippet = ""
             closer = parser.settings['commentCloser']
             if out:
                 if settings.get('jsdocs_spacer_between_sections'):
@@ -158,9 +158,10 @@ class JsdocsCommand(sublime_plugin.TextCommand):
                         if res and (lastTag != res.group(1)):
                             lastTag = res.group(1)
                             out.insert(idx, "")
-                snippet += ("\n " + prefix).join(out)
+                for line in out:
+                    snippet += "\n " + prefix + (indentSpaces + line if line else "")
             else:
-                snippet += "$0"
+                snippet += "\n " + prefix + indentSpaces + "$0"
 
             snippet += "\n" + closer
             write(v, snippet)


### PR DESCRIPTION
Avoid trailing spaces with jsdocs_spacer_between_sections enabled.

Makes sure that no indentation spaces are added when the line has
not text.
