### PR TITLE
Minor refactor of formatFunction to make TypeInfo reusable

### DIFF
--- a/jsdocs.py
+++ b/jsdocs.py
@@ -237,6 +237,17 @@ class JsdocsParser:
 
         return out
 
+    def getTypeInfo(self, argType, argName):
+        typeInfo = ''
+        if self.settings['typeInfo']:
+            typeInfo = '%s${1:%s}%s ' % (
+                "{" if self.settings['curlyTypes'] else "",
+                escape(argType or self.guessTypeFromName(argName) or "[type]"),
+                "}" if self.settings['curlyTypes'] else "",
+            )
+
+        return typeInfo
+
     def formatFunction(self, name, args, retval, options={}):
         out = []
         if 'as_setter' in options:
@@ -253,13 +264,8 @@ class JsdocsParser:
             # remove comments inside the argument list.
             args = re.sub("/\*.*?\*/", '', args)
             for argType, argName in self.parseArgs(args):
-                typeInfo = ''
-                if self.settings['typeInfo']:
-                    typeInfo = '%s${1:%s}%s ' % (
-                        "{" if self.settings['curlyTypes'] else "",
-                        escape(argType or self.guessTypeFromName(argName) or "[type]"),
-                        "}" if self.settings['curlyTypes'] else "",
-                    )
+                typeInfo = self.getTypeInfo(argType, argName)
+
                 out.append("@param %s%s ${1:[description]}" % (
                     typeInfo,
                     escape(argName)


### PR DESCRIPTION
A minor refactor of the `formatFunction` method of `parser` class.

Created the `getTypeInfo` method, which was inlined in `formatFunction` so it can be reused (i am working on extending the DocBlocr project to auto-updating on cursor keys).
