### PR TITLE
Check if autocomplete is enabled before showing it.

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -158,6 +158,7 @@
   // show the autocomplete
   { "keys": ["@"], "command": "run_macro_file", "args": {"file": "Packages/DocBlockr/jsdocs-auto-complete.sublime-macro"},
     "context": [
+      { "key": "setting.auto_complete", "operator": "equal",    "operand": true,                           "match_all": true },
       { "key": "selection_empty", "operator": "equal",          "operand": true,                           "match_all": true },
       { "key": "preceding_text",  "operator": "regex_contains", "operand": "^\\s*(?:\\/\\*|###)?\\*\\s*$", "match_all": true },
       { "key": "selector",        "operator": "equal",          "operand": "comment.block",                "match_all": true }


### PR DESCRIPTION
when i insert `@` in a block comment an autocomplete window is shown to me, i don't use autocomplete.

what this pull request will do is simply check if the user has enabled `auto_complete` before showing it..
