### PR TITLE
fixed small bug in parseArgs that returned an empty array when no arguments

### DIFF
--- a/jsdocs.py
+++ b/jsdocs.py
@@ -327,6 +327,9 @@ class JsdocsParser(object):
     def parseArgs(self, args):
         """ an array of tuples, the first being the best guess at the type, the second being the name """
         out = []
+
+        if not args: return out
+
         for arg in re.split('\s*,\s*', args):
             arg = arg.strip()
             out.append((self.getArgType(arg), self.getArgName(arg)))


### PR DESCRIPTION
the `parseArgs` function returned a bogus 1 element array when there were no arguments.

`re.split('\s*,\s*', args)` will return an array even if `args` is an empty string, thus the problem...
