### PR TITLE
Allow for PHP functions that return references.

### DIFF
--- a/jsdocs.py
+++ b/jsdocs.py
@@ -522,7 +522,7 @@ class JsdocsPHP(JsdocsParser):
 
     def parseFunction(self, line):
         res = re.search(
-            'function\\s+'
+            'function\\s+&?(?:\\s+)?'
             + '(?P<name>' + self.settings['fnIdentifier'] + ')'
             # function fnName
             # (arg1, arg2)


### PR DESCRIPTION
PHP allows functions and methods to return references to objects with the following format:

```
function &reference() {}
```

OR

```
function & reference() {}
```
