### PR TITLE
Python3 migration for Sublime Text 3

### DIFF
--- a/jsdocs.py
+++ b/jsdocs.py
@@ -7,6 +7,7 @@ import sublime
 import sublime_plugin
 import re
 import string
+from functools import reduce
 
 
 def read_line(view, point):
@@ -131,10 +132,10 @@ class JsdocsCommand(sublime_plugin.TextCommand):
             return self.createSnippet(out)
 
     def alignTags(self, out):
-        def outputWidth(str):
+        def outputWidth(input):
             # get the length of a string, after it is output as a snippet,
             # "${1:foo}" --> 3
-            return len(string.replace(re.sub("[$][{]\\d+:([^}]+)[}]", "\\1", str), '\$', '$'))
+            return len(str.replace(re.sub("[$][{]\\d+:([^}]+)[}]", "\\1", input), '\$', '$'))
 
         # count how many columns we have
         maxCols = 0
@@ -149,7 +150,7 @@ class JsdocsCommand(sublime_plugin.TextCommand):
 
         #  skip the first one, since that's always the "description" line
         for line in out[1:lastItem]:
-            widths.append(map(outputWidth, line.split(" ")))
+            widths.append(list(map(outputWidth, line.split(" "))))
             maxCols = max(maxCols, len(widths[-1]))
 
         #  initialise a list to 0
@@ -182,7 +183,7 @@ class JsdocsCommand(sublime_plugin.TextCommand):
         tabIndex = counter()
 
         def swapTabs(m):
-            return "%s%d%s" % (m.group(1), tabIndex.next(), m.group(2))
+            return "%s%d%s" % (m.group(1), next(tabIndex), m.group(2))
 
         for index, outputLine in enumerate(out):
             out[index] = re.sub("(\\$\\{)\\d+(:[^}]+\\})", swapTabs, outputLine)
@@ -397,7 +398,7 @@ class JsdocsParser(object):
             elif 'regex' in rule:
                 return re.search(rule['regex'], name)
 
-        return filter(checkMatch, self.viewSettings.get('jsdocs_notation_map', []))
+        return list(filter(checkMatch, self.viewSettings.get('jsdocs_notation_map', [])))
 
     def getDefinition(self, view, pos):
         """
@@ -412,7 +413,7 @@ class JsdocsParser(object):
         def countBrackets(total, bracket):
             return total + (1 if bracket == '(' else -1)
 
-        for i in xrange(0, maxLines):
+        for i in range(0, maxLines):
             line = read_line(view, pos)
             if line is None:
                 break
@@ -798,7 +799,7 @@ class JsdocsObjC(JsdocsParser):
         maxLines = 25  # don't go further than this
 
         definition = ''
-        for i in xrange(0, maxLines):
+        for i in range(0, maxLines):
             line = read_line(view, pos)
             if line is None:
                 break
@@ -836,7 +837,7 @@ class JsdocsObjC(JsdocsParser):
         if argStr:
             groups = re.split('\\s*:\\s*', argStr)
             numGroups = len(groups)
-            for i in xrange(0, numGroups):
+            for i in range(0, numGroups):
                 group = groups[i]
                 if i < numGroups - 1:
                     result = re.search(r'\s+(\S*)$', group)
@@ -957,7 +958,7 @@ class JsdocsReparse(sublime_plugin.TextCommand):
         tabIndex = counter()
 
         def tabStop(m):
-            return "${%d:%s}" % (tabIndex.next(), m.group(1))
+            return "${%d:%s}" % (next(tabIndex), m.group(1))
 
         v = self.view
         v.run_command('clear_fields')


### PR DESCRIPTION
I tried out DocBlockr in Sublime Text 3.  Sublime Text 3 is using python3 so several things didn't work.  I ran the 2to3 migration tool which took care of most items.  Then edited the outputWidth function in JsdocsCommand.alignTags, renamed
str to input and string.replace to str.replace.  Seems to work properly for me know.

I don't really expect you to merge this, just trying to help.  The Package Control project has a python3 branch for it's Sublime Text 3 compatible version, so that's why I named this branch that.

Cheers.  Thanks for the plugin!
