### PR TITLE
readme: Remove "www." from pledgie.com https url 

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ This is my first package for Sublime Text, and the first time I've written any P
 
 ## Show your love ##
 
-[![Click here to lend your support to: DocBlockr and make a donation at www.pledgie.com !](https://www.pledgie.com/campaigns/16316.png?skin_name=chrome)](http://www.pledgie.com/campaigns/16316)
+[![Click here to lend your support to: DocBlockr and make a donation at pledgie.com!](https://pledgie.com/campaigns/16316.png?skin_name=chrome)](http://pledgie.com/campaigns/16316)
 
 [closure]: http://code.google.com/closure/compiler/docs/js-for-compiler.html
 [issues]: https://github.com/spadgos/sublime-jsdocs/issues


### PR DESCRIPTION
The SSL certificate served on https://www.pledgie.com is invalid as it is for pledgie.com, not www.pledgie.com.

The url was blocked in modern browsers (such as Chrome).

Kept anchor url on HTTP as their HTTPS site is a mess (all urls still point to HTTP, individual resources such as images work fine over HTTPS, which is to make sure the image url isn't blocked when using GitHub, which is HTTPS enforced).
