### PR TITLE
Python 3 compatibility fix

### DIFF
--- a/jsdocs.py
+++ b/jsdocs.py
@@ -209,7 +209,7 @@ class JsdocsCommand(sublime_plugin.TextCommand):
         def subLine(line):
             return re.sub(r'\{\{([^}]+)\}\}', getVar, line)
 
-        return map(subLine, out)
+        return list(map(subLine, out))
 
     def fixTabStops(self, out):
         tabIndex = counter()


### PR DESCRIPTION
I encapsulated the map function of the parse method by
list to get a proper list instead of a map object

Without this fix i couldn't use DocBlockr with PHP because it failed with this error:

```
Traceback (most recent call last):
  File "/Applications/Sublime Text 3.app/Contents/MacOS/sublime_plugin.py", line 549, in run_
    return self.run(edit)
  File "/Users/mneuhaus/Library/Application Support/Sublime Text 3/Packages/DockBlockr/jsdocs.py", line 86, in run
    snippet = self.generateSnippet(out, inline)
  File "/Users/mneuhaus/Library/Application Support/Sublime Text 3/Packages/DockBlockr/jsdocs.py", line 130, in generateSnippet
    out = self.fixTabStops(out)
  File "/Users/mneuhaus/Library/Application Support/Sublime Text 3/Packages/DockBlockr/jsdocs.py", line 221, in fixTabStops
    out[index] = re.sub("(\\$\\{)\\d+(:[^}]+\\})", swapTabs, outputLine)
TypeError: 'map' object does not support item assignment
```
