### PR TITLE
Small fix for documentation of forward declarations of functions.

### DIFF
--- a/jsdocs.py
+++ b/jsdocs.py
@@ -681,7 +681,7 @@ class JsdocsCPP(JsdocsParser):
     def parseFunction(self, line):
         res = re.search(
             '(?P<retval>' + self.settings['varIdentifier'] + ')[&*\\s]+'
-            + '(?P<name>' + self.settings['varIdentifier'] + ')'
+            + '(?P<name>' + self.settings['varIdentifier'] + ');?'
             # void fnName
             # (arg1, arg2)
             + '\\s*\\(\\s*(?P<args>.*)\)',


### PR DESCRIPTION
Only applicable to the JsdocsCPP class, i.e. only C/C++.
