### PR TITLE
Option to use @property tag for variable definitions. [Important for YUIDoc]

### DIFF
--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -95,6 +95,9 @@
   // indicates whether the @method tag should be added automatically
   "jsdocs_autoadd_method_tag": false,
 
+  // indicates whether the @property should be used for variable definition instead of @type
+  "jsdocs_var_use_property_tag": false,
+
   // If set to true, DocBlockr won't parse any code, providing no default templates. All other functions work as normal.
   "jsdocs_simple_mode": false,
 

--- a/jsdocs.py
+++ b/jsdocs.py
@@ -280,21 +280,40 @@ class JsdocsParser(object):
         else:
             valType = self.guessTypeFromValue(val) or self.guessTypeFromName(name) or "[type]"
 
-        if self.inline:
-            out.append("@%s %s${1:%s}%s ${1:[description]}" % (
-                self.settings['typeTag'],
-                "{" if self.settings['curlyTypes'] else "",
-                valType,
-                "}" if self.settings['curlyTypes'] else ""
-            ))
+        if (self.viewSettings.get("jsdocs_var_use_property_tag") is False):
+            if self.inline:
+                out.append("@%s %s${1:%s}%s ${1:[description]}" % (
+                    self.settings['typeTag'],
+                    "{" if self.settings['curlyTypes'] else "",
+                    valType,
+                    "}" if self.settings['curlyTypes'] else ""
+                ))
+            else:
+                out.append("${1:[%s description]}" % (escape(name)))
+                out.append("@%s %s${1:%s}%s" % (
+                    self.settings['typeTag'],
+                    "{" if self.settings['curlyTypes'] else "",
+                    valType,
+                    "}" if self.settings['curlyTypes'] else ""
+                ))
         else:
-            out.append("${1:[%s description]}" % (escape(name)))
-            out.append("@%s %s${1:%s}%s" % (
-                self.settings['typeTag'],
-                "{" if self.settings['curlyTypes'] else "",
-                valType,
-                "}" if self.settings['curlyTypes'] else ""
-            ))
+            if self.inline:
+                out.append("@%s %s${1:%s}%s %s ${1:[description]}" % (
+                    "property",
+                    "{" if self.settings['curlyTypes'] else "",
+                    valType,
+                    "}" if self.settings['curlyTypes'] else "",
+                    escape(name)
+                ))
+            else:
+                out.append("${1:[%s description]}" % (escape(name)))
+                out.append("@%s %s${1:%s}%s %s" % (
+                    "property",
+                    "{" if self.settings['curlyTypes'] else "",
+                    valType,
+                    "}" if self.settings['curlyTypes'] else "",
+                    escape(name)
+                ))
 
         return out
 


### PR DESCRIPTION
Added a single option for the package to use @property tag for the variable definition instead of @type tag, which is used by default.

This is crucial for YUIDoc documentation tool, since it only recognises definitions that have one of the primary tags:
@module, @class, @method, @property, @event

Currently DocBlockr has option to add @method tag to function declarations which is perfect for YUIDoc.

This patch adds the same functionality for variables.

And thank you so much for creating such a great tool. It is very nicely programmed and works amazingly.
Developing your code is also a pleasure.
Cheers, Nazar.
