### PR TITLE
Add support for triple ///, //! and /*! style comments + basic Rust support

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -5,7 +5,7 @@
       { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                        "match_all": true },
       { "key": "selection_empty",       "operator": "equal",          "operand": true,                        "match_all": true },
       { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                       "match_all": true },
-      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\\/\\*|###)\\*\\s*$", "match_all": true }
+      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\\/\\*|###)[*!]\\s*$", "match_all": true }
     ]
   },
   // open a docblock with keypad enter
@@ -14,7 +14,7 @@
       { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                        "match_all": true },
       { "key": "selection_empty",       "operator": "equal",          "operand": true,                        "match_all": true },
       { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                       "match_all": true },
-      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\\/\\*|###)\\*\\s*$", "match_all": true }
+      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\\/\\*|###)[*!]\\s*$", "match_all": true }
     ]
   },
   // open a docblock with tab
@@ -23,7 +23,7 @@
       { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                        "match_all": true },
       { "key": "selection_empty",       "operator": "equal",          "operand": true,                        "match_all": true },
       { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                       "match_all": true },
-      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\\/\\*|###)\\*\\s*$", "match_all": true }
+      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\\/\\*|###)[*!]\\s*$", "match_all": true }
     ]
   },
   // extend a docblock by adding an asterisk at the start
@@ -76,23 +76,23 @@
     ]
   },
   // extend line comments (// and #)
-  { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n${TM_CURRENT_LINE/^\\s*((?:#|\\/\\/)\\s*).*/$1/}"},
+  { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n${TM_CURRENT_LINE/^\\s*((?:#|\\/\\/[\\/!]?)\\s*).*/$1/}"},
     "context": [
       { "key": "setting.auto_indent",                "operator": "equal",          "operand": true,              "match_all": true },
       { "key": "setting.jsdocs_extend_double_slash", "operator": "equal",          "operand": true,              "match_all": true },
       { "key": "selector",                           "operator": "equal",          "operand": "comment.line",    "match_all": true },
       { "key": "auto_complete_visible",              "operator": "equal",          "operand": false,             "match_all": true },
-      { "key": "preceding_text",                     "operator": "regex_contains", "operand": "^\\s*(\\/\\/|#)", "match_all": true }
+      { "key": "preceding_text",                     "operator": "regex_contains", "operand": "^\\s*(\\/\\/[\\/!]?|#)", "match_all": true }
     ]
   },
   // extend line comments (// #) with keypad enter
-  { "keys": ["keypad_enter"], "command": "insert_snippet", "args": {"contents": "\n${TM_CURRENT_LINE/^\\s*((?:#|\\/\\/)\\s*).*$/$1/}"},
+  { "keys": ["keypad_enter"], "command": "insert_snippet", "args": {"contents": "\n${TM_CURRENT_LINE/^\\s*((?:#|\\/\\/[\\/!]?)\\s*).*$/$1/}"},
     "context": [
       { "key": "setting.auto_indent",                "operator": "equal",          "operand": true,           "match_all": true },
       { "key": "setting.jsdocs_extend_double_slash", "operator": "equal",          "operand": true,           "match_all": true },
       { "key": "selector",                           "operator": "equal",          "operand": "comment.line", "match_all": true },
       { "key": "auto_complete_visible",              "operator": "equal",          "operand": false,          "match_all": true },
-      { "key": "preceding_text",                     "operator": "regex_contains", "operand": "^\\s*\\/\\/",  "match_all": true }
+      { "key": "preceding_text",                     "operator": "regex_contains", "operand": "^\\s*\\/\\/[\\/!]?",  "match_all": true }
     ]
   },
   // close a block comment (/*  */)

--- a/jsdocs.py
+++ b/jsdocs.py
@@ -64,6 +64,8 @@ def getParser(view):
         return JsdocsObjC(viewSettings)
     elif sourceLang == 'java' or sourceLang == 'groovy':
         return JsdocsJava(viewSettings)
+    elif sourceLang == 'rust':
+        return JsdocsRust(viewSettings)
     return JsdocsJavascript(viewSettings)
 
 
@@ -1089,6 +1091,32 @@ class JsdocsJava(JsdocsParser):
                 break
         return definition
 
+class JsdocsRust(JsdocsParser):
+    def setupSettings(self):
+        self.settings = {
+            "curlyTypes": False,
+            'typeInfo': False,
+            "typeTag": False,
+            "varIdentifier": ".*",
+            "fnIdentifier":  ".*",
+            "fnOpener": "^\s*fn",
+            "commentCloser": " */",
+            "bool": "Boolean",
+            "function": "Function"
+        }
+
+    def parseFunction(self, line):
+        res = re.search('\s*fn\s+(?P<name>\S+)', line)
+        if not res:
+            return None
+
+        name = res.group('name').join('');
+
+        return (name, [])
+
+    def formatFunction(self, name, args):
+        return name
+
 ############################################################33
 
 
@@ -1133,7 +1161,7 @@ class JsdocsJoinCommand(sublime_plugin.TextCommand):
         v = self.view
         for sel in v.sel():
             for lineRegion in reversed(v.lines(sel)):
-                v.replace(edit, v.find("[ \\t]*\\n[ \\t]*((?:\\*|//|#)[ \\t]*)?", lineRegion.begin()), ' ')
+                v.replace(edit, v.find("[ \\t]*\\n[ \\t]*((?:\\*|//[!/]?|#)[ \\t]*)?", lineRegion.begin()), ' ')
 
 
 class JsdocsDecorateCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
This adds support for:
- rust-style `///` triple slash docblocks (also fixes #214).
- rust `//!` and `/*!` comments for documenting modules.
- adds a very dumb JsdocsRust class that just suppresses all docblock generation because we don't have any of that in rust.

I hope it's all reasonable changes :)
