### PR TITLE
Open documentation feature

### DIFF
--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -103,5 +103,12 @@
 
   // This property affects the default tag added to `var` declarations in Javascript/Coffeescript. If `false`, the
   // default is used ("var"), otherwise it can be set to any String, eg: "property"
-  "jsdocs_override_js_var": false
+  "jsdocs_override_js_var": false,
+
+  // The absolute path to the local docs folder
+  // example: "/Users/rob/projects/project/docs/build"
+  "jsdocs_local_docs_url": "local_path_to_your_project_documentation_build_folder",
+  // The URL of the live documentation build folder
+  // example: "http://robertpataki.com/docs/build"
+  "jsdocs_live_docs_url": "remote_path_to_your_project_documentation_build_folder"
 }

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,3 +25,4 @@ Many thanks to all those who have sent bug reports and especially to those who s
 - Tiago Santos (@tmcsantos)
 - Timo Tijhof (@Krinkle)
 - wronex (@wronex)
+- Robert Pataki (@heartcode)

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,0 +1,16 @@
+[{
+    "caption": "DocBlockr",
+    "children": [{
+        "caption": "Open live docs",
+        "command": "jsdocs_open_live_docs"
+    }, {
+        "caption": "Open live docs at this file",
+        "command": "jsdocs_open_live_docs_at_file"
+    }, {
+        "caption": "Open local docs",
+        "command": "jsdocs_open_local_docs"
+    }, {
+        "caption": "Open local docs at this file",
+        "command": "jsdocs_open_local_docs_at_file"
+    }]
+}]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -242,5 +242,11 @@
       { "key": "auto_complete_visible", "operator": "equal",          "operand": false,           "match_all": true },
       { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*\\*",      "match_all": true }
     ]
-  }
+  },
+
+  // Open live or local documentation
+  { "keys": ["super+alt+;"], "command": "jsdocs_open_live_docs" },
+  { "keys": ["super+alt+'"], "command": "jsdocs_open_live_docs_at_file" },
+  { "keys": ["super+alt+,"], "command": "jsdocs_open_local_docs" },
+  { "keys": ["super+alt+."], "command": "jsdocs_open_local_docs_at_file" }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,5 +1,25 @@
 [
     {
+        "id": "tools",
+        "children": [{
+            "id": "docblockr_tools",
+            "caption": "DocBlockr",
+            "children": [{
+                "caption": "Open live docs",
+                "command": "jsdocs_open_live_docs"
+            }, {
+                "caption": "Open live docs at this file",
+                "command": "jsdocs_open_live_docs_at_file"
+            }, {
+                "caption": "Open local docs",
+                "command": "jsdocs_open_local_docs"
+            }, {
+                "caption": "Open local docs at this file",
+                "command": "jsdocs_open_local_docs_at_file"
+            }]
+        }]
+    },
+    {
         "caption": "Preferences",
         "mnemonic": "n",
         "id": "preferences",

--- a/README.md
+++ b/README.md
@@ -159,6 +159,27 @@ Inside a comment block, hit `Alt+Q` to wrap the lines to make them fit within yo
 
 Finally, typing `@` inside a docblock will show a completion list for all tags supported by [JSDoc][jsdoc], the [Google Closure Compiler][closure], [YUIDoc][yui] or [PHPDoc][phpdoc]. Extra help is provided for each of these tags by prefilling the arguments each expects. Pressing `tab` will move the cursor to the next argument.
 
+### Opening your projects JSDoc documentation ###
+
+You probably have your JSDoc documentation sitting somewhere in the project folder on your machine, or somewhere on the server. If so, you'll probably find it useful to being able to open your documentation directly from Sublime. You can either open your local or live documentation and you can even go straight to the documentation page of the currently edited file.
+
+To access the documentation opening feature, simply right click on an file while editing and select 'DocBlockr' and choose one of the options:
+
+- Open live docs
+	- Opens the live (remote URL) documentation index in your web browser
+- Open live docs at file:
+	- Opens the live documentation of the file you are currently editing
+- Open local docs
+	- Opens the local documentation index
+- Open local docs at file:
+	- Opens the local documentation of the file you are currently editing
+
+You can access these commands from the `Tools -> DocBlockr` menu or by using keyboard shortcuts
+
+For help with setting up DocBlockr being able to open your project's JSDOC documentation, see the configuration section below.
+
+Only Supports JSDOC at the moment
+
 ## Configuration ##
 
 You can access the configuration settings by selecting `Preferences -> Package Settings -> DocBlockr`.
@@ -242,6 +263,24 @@ You can access the configuration settings by selecting `Preferences -> Package S
 - `jsdocs_simple_mode` *(Boolean)* If true, DocBlockr won't add a template when creating a doc block before a function or variable. Useful if you don't want to write Javadoc-style, but still want your editor to help when writing block comments. Default: `false`
 
 - `jsdocs_lower_case_primitives` *(Boolean)* If true, primitive data types are added in lower case, eg "number" instead of "Number". Default: `false`
+
+- `jsdocs_live_docs_url` *(String)* The path to the live project documentation. This URL should point to the remote documentation build folder.
+- `jsdocs_local_docs_url` *(String)* The path to the local project documentation's build folder. In Sublime 3 both default and user settings for these two options can be overridden using a project file - letting you open the currently open project's documentation:
+
+		// `project.sublime-project` file
+		{
+			"settings":
+			{
+  				"tab_size": 4,
+  				"jsdocs":
+				{
+					"jsdocs_local_docs_url": "/Users/you/projects/project/docs/jsdoc/build",
+					"jsdocs_live_docs_url": "http://yourproject.com/docs/build"
+				}
+			}
+		}
+
+
 
 This is my first package for Sublime Text, and the first time I've written any Python, so I heartily welcome feedback and [feature requests or bug reports][issues].
 


### PR DESCRIPTION
I realised just now that I wrongly made a pull request from my `rob` branch into your `master` branch, so I made a new pull request from my `develop` into your `develop`.

This PR contains code refactoring based on your feedback:
- Move the keyboard shortcuts from the OSX into default mapping file
- Replace the `try/catch` blocks with conditional statements and sanity checks
- Remove the debugger print lines

---

Let the user open their documentation straight away from Sublime by using contextual menu or keyboard shortcuts. The user can configure the package globally using the default and user settings, or on a per project basis using sublime-project files (Sublime 3 only).

Feature commands:
- Open live documentation index in web browser
- Open live documentation of currently edited in web browser
- Open local documentation index in web browser
- Open local documentation of currently edited file in web browser

Settings used by the feature:
`jsdoc_live_docs_url` - The URL of the live project documentation's build folder
`jsdoc_local_docs_url` - The path to the local project documentation's build folder
