### PR TITLE
Add support for short primitives in JS and PHP.

### DIFF
--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -101,6 +101,9 @@
   // If set to true, primitives such as "Number" and "String" will be documented as "number" and "string".
   "jsdocs_lower_case_primitives": false,
 
+  // If set to true, primitived such as "boolean" and "integer" will be shortened to "bool" and "int".
+  "jsdocs_short_primitives": false,
+
   // This property affects the default tag added to `var` declarations in Javascript/Coffeescript. If `false`, the
   // default is used ("var"), otherwise it can be set to any String, eg: "property"
   "jsdocs_override_js_var": false

--- a/jsdocs.py
+++ b/jsdocs.py
@@ -591,6 +591,7 @@ class JsdocsJavascript(JsdocsParser):
 
     def guessTypeFromValue(self, val):
         lowerPrimitives = self.viewSettings.get('jsdocs_lower_case_primitives') or False
+        shortPrimitives = self.viewSettings.get('jsdocs_short_primitives') or False
         if is_numeric(val):
             return "number" if lowerPrimitives else "Number"
         if val[0] == '"' or val[0] == "'":
@@ -600,7 +601,8 @@ class JsdocsJavascript(JsdocsParser):
         if val[0] == '{':
             return "Object"
         if val == 'true' or val == 'false':
-            return "boolean" if lowerPrimitives else "Boolean"
+            returnVal = 'Bool' if shortPrimitives else 'Boolean'
+            return returnVal.lower() if lowerPrimitives else returnVal
         if re.match('RegExp\\b|\\/[^\\/]', val):
             return 'RegExp'
         if val[:4] == 'new ':
@@ -611,6 +613,7 @@ class JsdocsJavascript(JsdocsParser):
 
 class JsdocsPHP(JsdocsParser):
     def setupSettings(self):
+        shortPrimitives = self.viewSettings.get('jsdocs_short_primitives') or False
         nameToken = '[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*'
         self.settings = {
             # curly brackets around the type information
@@ -621,7 +624,7 @@ class JsdocsPHP(JsdocsParser):
             'fnIdentifier': nameToken,
             'fnOpener': 'function(?:\\s+' + nameToken + ')?\\s*\\(',
             'commentCloser': ' */',
-            'bool': "boolean",
+            'bool': 'bool' if shortPrimitives else 'boolean',
             'function': "function"
         }
 
@@ -682,20 +685,22 @@ class JsdocsPHP(JsdocsParser):
         return None
 
     def guessTypeFromValue(self, val):
+        shortPrimitives = self.viewSettings.get('jsdocs_short_primitives') or False
         if is_numeric(val):
-            return "float" if '.' in val else "integer"
+            return "float" if '.' in val else 'int' if shortPrimitives else 'integer'
         if val[0] == '"' or val[0] == "'":
             return "string"
         if val[:5] == 'array':
             return "array"
         if val.lower() in ('true', 'false', 'filenotfound'):
-            return 'boolean'
+            return 'bool' if shortPrimitives else 'boolean'
         if val[:4] == 'new ':
             res = re.search('new (' + self.settings['fnIdentifier'] + ')', val)
             return res and res.group(1) or None
         return None
 
     def getFunctionReturnType(self, name, retval):
+        shortPrimitives = self.viewSettings.get('jsdocs_short_primitives') or False
         if (name[:2] == '__'):
             if name in ('__construct', '__destruct', '__set', '__unset', '__wakeup'):
                 return None
@@ -704,7 +709,7 @@ class JsdocsPHP(JsdocsParser):
             if name == '__toString':
                 return 'string'
             if name == '__isset':
-                return 'boolean'
+                return 'bool' if shortPrimitives else 'boolean'
         return JsdocsParser.getFunctionReturnType(self, name, retval)
 
 


### PR DESCRIPTION
This adds support for "bool" and "int" in place of "boolean" and "integer".
