### PR TITLE
Improves handling of Java methods with void return type.

### DIFF
--- a/jsdocs.py
+++ b/jsdocs.py
@@ -989,7 +989,7 @@ class JsdocsJava(JsdocsParser):
         line = line.strip()
         res = re.search(
             # Modifiers
-            '(?:public|protected|private|static|abstract|final|transient|synchronized|native|strictfp){0,1}\s*'
+            '(?:(public|protected|private|static|abstract|final|transient|synchronized|native|strictfp)\s+)*'
             # Return value
             + '(?P<retval>[a-zA-Z_$][\<\>\., a-zA-Z_$0-9]+)\s+'
             # Method name


### PR DESCRIPTION
I noticed that the `@return` tag was being added for Java methods that returned void but had multiple keywords, like `public static void foo()`, so I altered the regex so that it captures all of the keywords and therefore properly recognizes the void return type.
