### PR TITLE
Added the 'Expand Decoration' feature to JS

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -194,6 +194,12 @@
       { "key": "selector", "operator": "equal", "operand": "comment.line.double-slash"}
     ]
   },
+  // decorate and expand double-slash comment
+  { "keys": ["shift+ctrl+enter"], "command": "jsdocs_decorate_expand",
+    "context": [
+      { "key": "selector", "operator": "equal", "operand": "comment.line.double-slash"}
+    ]
+  },
   // decorate a double-slash comment
   { "keys": ["ctrl+keypad_enter"], "command": "jsdocs_decorate",
     "context": [

--- a/jsdocs.py
+++ b/jsdocs.py
@@ -1192,6 +1192,17 @@ class JsdocsDecorateCommand(sublime_plugin.TextCommand):
             v.insert(edit, sel.begin(), "/" * (lineLength + 3) + "\n")
 
 
+class JsdocsDecorateExpandCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        v = self.view
+        for region in v.sel():
+            line    = v.line(region)
+            linestr = v.substr(line)
+            newline    = '//' + ' '.join(list(linestr.upper().replace('//', '')))[1:]
+            v.replace(edit, line, newline)
+            v.run_command('jsdocs_decorate')
+
+
 class JsdocsDeindent(sublime_plugin.TextCommand):
     """
     When pressing enter at the end of a docblock, this takes the cursor back one space.


### PR DESCRIPTION
A new features that allows "bolder" box comments. For example, the standard Ctrl+Enter on this line

// Test

gives:

/////////////
// Test //
/////////////

This feature adds a bolder block, so that Shift+Ctrl+Enter makes "// Test" into

//////////////////
// T E S T //
//////////////////
