### PR TITLE
Changed return value regex in Java for supporting arrays

### DIFF
--- a/jsdocs.py
+++ b/jsdocs.py
@@ -1009,7 +1009,7 @@ class JsdocsJava(JsdocsParser):
             # Modifiers
             '(?:(public|protected|private|static|abstract|final|transient|synchronized|native|strictfp)\s+)*'
             # Return value
-            + '(?P<retval>[a-zA-Z_$][\<\>\., a-zA-Z_$0-9]+)(\[\])*\s+'
+            + '(?P<retval>[a-zA-Z_$][\<\>\., a-zA-Z_$0-9]+(\[\])*)\s+'
             # Method name
             + '(?P<name>' + self.settings['fnIdentifier'] + ')\s*'
             # Params


### PR DESCRIPTION
Function parser for Java doesn't work if the return value is an Array, like int[].
With this change it should work now :smiley:.
