### PR TITLE
Fixed link to Contributing.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ You can access the configuration settings by selecting `Preferences -> Package S
 This is my first package for Sublime Text, and the first time I've written any Python, so I heartily welcome feedback and [feature requests or bug reports][issues].
 
 [closure]: http://code.google.com/closure/compiler/docs/js-for-compiler.html
-[contrib]: blob/master/CONTRIBUTING.md
+[contrib]: CONTRIBUTING.md
 [issues]: https://github.com/spadgos/sublime-jsdocs/issues
 [jsdoc]: http://code.google.com/p/jsdoc-toolkit/wiki/TagReference
 [magicmethods]: http://www.php.net/manual/en/language.oop5.magic.php


### PR DESCRIPTION
The link was broken in the GitHub Readme.md file.

The link is also broken on the [Package Control site](https://sublime.wbond.net/packages/DocBlockr), which appears to be generated from the same file, but I am not sure if this will really fix that.

By the way: great plugin, thanks for your work!
