### PR TITLE
Fixes DocBlockr not working when Java method expects to return array

### DIFF
--- a/jsdocs.py
+++ b/jsdocs.py
@@ -1009,7 +1009,7 @@ class JsdocsJava(JsdocsParser):
             # Modifiers
             '(?:(public|protected|private|static|abstract|final|transient|synchronized|native|strictfp)\s+)*'
             # Return value
-            + '(?P<retval>[a-zA-Z_$][\<\>\., a-zA-Z_$0-9]+)\s+'
+            + '(?P<retval>[a-zA-Z_$][\<\>\., a-zA-Z_$0-9]+(\w+)((\[\])*))\s+'
             # Method name
             + '(?P<name>' + self.settings['fnIdentifier'] + ')\s*'
             # Params


### PR DESCRIPTION
This fix should resolve #303. I have tested it on my machine and it is working.
