### PR TITLE
Fix #286 PHP namespaced params are missing the `\` namespace characters 

### DIFF
--- a/jsdocs.py
+++ b/jsdocs.py
@@ -446,12 +446,13 @@ class JsdocsParser(object):
             if nextIsLiteral:  # previous char was a \
                 current += char
                 nextIsLiteral = False
-            elif char == '\\':
-                nextIsLiteral = True
             elif insideQuotes:
-                current += char
-                if char == matchingQuote:
-                    insideQuotes = False
+                if char == '\\':
+                    nextIsLiteral = True
+                else:
+                    current += char
+                    if char == matchingQuote:
+                        insideQuotes = False
             else:
                 if char == ',':
                     blocks.append(current.strip())

--- a/tests/php.py
+++ b/tests/php.py
@@ -19,3 +19,18 @@ def test_for_issue_292_php_args_pass_by_reference_missing_ampersand_char(helper)
         " */",
         "function function_name($a1,  $a2 = 'x', array $a3, &$b1, &$b2 = 'x', array &$b3) {}"
     ]
+
+def test_for_issue_286_php_args_namespace_char_is_missing(helper):
+    "PHP namespaces are 'mutilated' for namespaced params https://github.com/spadgos/sublime-jsdocs/issues/286"
+
+    helper.insert("/**|\nfunction function_name(A\NS\ClassName $class) {}")
+    helper.run()
+
+    return [
+        "/**",
+        " * |[function_name description]|",
+        " * @param  A\NS\ClassName $class [description]",
+        " * @return {[type]}                [description]",
+        " */",
+        "function function_name(A\NS\ClassName $class) {}"
+    ]


### PR DESCRIPTION
Fix https://github.com/spadgos/sublime-jsdocs/issues/286

I'm not sure if there was a reason the `\` character was skipped when parsing arguments. PHP namespace character is `\`.

I was [unable to run the tests](https://github.com/spadgos/sublime-jsdocs/issues/307), but have added a test based on the existing ones. It should pass.
