### PR TITLE
Add `jsdoc_insert_unknown_return_type` setting

### DIFF
--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -53,6 +53,9 @@
   // A map to determine the value of variables, should hungarian notation (or similar) be in use
   "jsdocs_notation_map": [],
 
+  // Add a "@return" tag even if the return type cannot be determined
+  "jsdoc_insert_unknown_return_type": true,
+
   // Since there seems to be no agreed standard for "@return" or "@returns", use this setting to rename it as you wish.
   "jsdocs_return_tag": "@return",
 

--- a/jsdocs.py
+++ b/jsdocs.py
@@ -423,7 +423,7 @@ class JsdocsParser(object):
         # return value type might be already available in some languages but
         # even then ask language specific parser if it wants it listed
         retType = self.getFunctionReturnType(name, retval)
-        if retType is not None:
+        if (retType is not None and (retType or self.viewSettings.get('jsdoc_insert_unknown_return_type'))):
             typeInfo = ''
             if self.settings['typeInfo']:
                 typeInfo = ' %s${1:%s}%s' % (


### PR DESCRIPTION
Currently, DocBlockr will insert a return tag if it hasn't "ruled out" the possibility of a function return. If it hasn't determined a return type, but hasn't ruled out a return, then it adds a `@return` tag with no type.

This isn't always desirable behavior, as it is often easier to add a new `@return` tag on the fly, then to have to do a complicated delete that doesn't break the formatting (you either have to do a shift-home delete backspace backspace backspace, or select with a mouse, neither of which are fast).

I added a setting (defaulted to not change the current behavior) that will change whether or not a `@return` tag is inserted if no return type could be determined.

| jsdoc_insert_unknown_return_type | Return Confirmed | Return Unknown | Return Ruled Out | 
| ------------- | ---------------------------------- | --------------------------------- | --------------------------------- |
| true (default - old behaviour) | add tag | add tag | don't add tag |
| false | add tag | don't add tag | don't add tag |



