### PR TITLE
Add syntax highlighting for JavaScript

### DIFF
--- a/JavaScript-DocBlockr.YAML-tmLanguage
+++ b/JavaScript-DocBlockr.YAML-tmLanguage
@@ -1,0 +1,17 @@
+# [PackageDev] target_format: plist, ext: tmLanguage
+---
+name: JavaScript DocBlockr
+scopeName: source.js.docblockr
+fileTypes: [js]
+uuid: 27fe7d8c-8d0a-4d30-96e3-47e47b9d6b77
+
+patterns:
+- name: comment.block.documentation.docblockr
+  begin: '/\*\*'
+  end: '\*/'
+  patterns:
+  - name: keyword.other.docblockr
+    match: '@\w+'
+
+- include: source.js
+...

--- a/JavaScript-DocBlockr.tmLanguage
+++ b/JavaScript-DocBlockr.tmLanguage
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>fileTypes</key>
+	<array>
+		<string>js</string>
+	</array>
+	<key>name</key>
+	<string>JavaScript DocBlockr</string>
+	<key>patterns</key>
+	<array>
+		<dict>
+			<key>begin</key>
+			<string>/\*\*</string>
+			<key>end</key>
+			<string>\*/</string>
+			<key>name</key>
+			<string>comment.block.documentation.docblockr</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>@\w+</string>
+					<key>name</key>
+					<string>keyword.other.docblockr</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>source.js</string>
+		</dict>
+	</array>
+	<key>scopeName</key>
+	<string>source.js.docblockr</string>
+	<key>uuid</key>
+	<string>27fe7d8c-8d0a-4d30-96e3-47e47b9d6b77</string>
+</dict>
+</plist>


### PR DESCRIPTION
https://github.com/spadgos/sublime-jsdocs/issues/336

I created syntax definitions for DocBlockr.

This is very basic, but it's a start. From here on you can use this as a template to add syntax definitions for all use cases. 

If you now go to View->Syntax, you will see `JavaScript DocBlockr` under `JavaScript`. Selecting `JavaScript DocBlockr` will give you javascript syntax with jsdoc tag highlighting. You can also configure `JavaScript DocBlockr` to be the default syntax for all .js files.

![image](https://cloud.githubusercontent.com/assets/6479817/5408308/502b458c-818c-11e4-83ab-e905d8d73098.png)

I also included the source .YAML-tmLanguage file which you can use to compile the .tmLanguage XML with the [AAAPackageDev](https://github.com/SublimeText/AAAPackageDev) plugin.
