### PR TITLE
add ability to extend parser settings

### DIFF
--- a/jsdocs.py
+++ b/jsdocs.py
@@ -140,15 +140,15 @@ class JsdocsCommand(sublime_plugin.TextCommand):
         # reassign parser settings if needed
         self.parser.settings.update(options);
 
+        # use another prefix if needed
+        self.prefix = prefix;
+
         if self.parser.isExistingComment(self.line):
-            write(self.view, "\n *" + self.indentSpaces)
+            write(self.view, "\n" + self.prefix + self.indentSpaces)
             return
 
         # erase characters in the view (will be added to the output later)
         self.view.erase(edit, self.trailingRgn)
-
-        # use another prefix if needed
-        self.prefix = prefix;
 
         # match against a function declaration.
         out = self.parser.parse(self.line)

--- a/jsdocs.py
+++ b/jsdocs.py
@@ -133,9 +133,12 @@ def flatten(theList):
 
 class JsdocsCommand(sublime_plugin.TextCommand):
 
-    def run(self, edit, inline=False):
+    def run(self, edit, inline=False, prefix=" *", options = {}):
 
         self.initialize(self.view, inline)
+
+        # reassign parser settings if needed
+        self.parser.settings.update(options);
 
         if self.parser.isExistingComment(self.line):
             write(self.view, "\n *" + self.indentSpaces)
@@ -143,6 +146,9 @@ class JsdocsCommand(sublime_plugin.TextCommand):
 
         # erase characters in the view (will be added to the output later)
         self.view.erase(edit, self.trailingRgn)
+
+        # use another prefix if needed
+        self.prefix = prefix;
 
         # match against a function declaration.
         out = self.parser.parse(self.line)
@@ -163,7 +169,8 @@ class JsdocsCommand(sublime_plugin.TextCommand):
         self.trailingString = escape(re.sub('\\s*\\*\\/\\s*$', '', self.trailingString))
 
         self.indentSpaces = " " * max(0, self.settings.get("jsdocs_indentation_spaces", 1))
-        self.prefix = "*"
+
+        self.prefix = " *"
 
         settingsAlignTags = self.settings.get("jsdocs_align_tags", 'deep')
         self.deepAlignTags = settingsAlignTags == 'deep'
@@ -309,9 +316,9 @@ class JsdocsCommand(sublime_plugin.TextCommand):
                             out.insert(idx, "")
                         lastLineIsTag = True
             for line in out:
-                snippet += "\n " + self.prefix + (self.indentSpaces + line if line else "")
+                snippet += "\n" + self.prefix + (self.indentSpaces + line if line else "")
         else:
-            snippet += "\n " + self.prefix + self.indentSpaces + "${0:" + self.trailingString + '}'
+            snippet += "\n" + self.prefix + self.indentSpaces + "${0:" + self.trailingString + '}'
 
         snippet += "\n" + closer
         return snippet


### PR DESCRIPTION
Hi, i know nothing about sublime text plugin architecture, but i'll be happy to have an ability to use [codo](https://github.com/coffeedoc/codo) with this plugin. There are minimal (but may be not valid) changes to make it possible.
##### My use case for codo:

``` coffee
  #<enter>
  render: ->
    <div>LDAP VIEW</div>

  # becomes

  #
  # [render description]
  # @return {[type]} [description]
  #
  render: ->
    <div>LDAP VIEW</div> 
```
##### Keymap:

``` json
    // open a docblock with enter
    {
        "keys": [
            "enter"
        ], 
        "command": "jsdocs",
        "args": {
            "prefix": "#",
            "options": {
                "commentCloser": "#"
            }
        },
        "context": [
            { 
                "key": "setting.auto_indent",
                "operator": "equal",
                "operand": true,
                "match_all": true 
            },
            { 
                "key": "selection_empty",
                "operator": "equal",          
                "operand": true,                         
                "match_all": true 
            },
            { 
                "key": "auto_complete_visible", 
                "operator": "equal",          
                "operand": false,                        
                "match_all": true 
            },
            { 
                "key": "selector", 
                "operator": "equal", 
                "operand": "source.coffee" 
            },
            { 
                "key": "preceding_text",        
                "operator": "regex_contains", 
                "operand": "^\\s*(#)\\s*$", 
                "match_all": true 
            }
        ]
    }
```

Thanks, anyway.
