### PR TITLE
Rename settings and the way settings are loaded

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -79,7 +79,7 @@
   { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n${TM_CURRENT_LINE/^\\s*((?:#|\\/\\/[\\/!]?)\\s*).*/$1/}"},
     "context": [
       { "key": "setting.auto_indent",                "operator": "equal",          "operand": true,              "match_all": true },
-      { "key": "setting.jsdocs_extend_double_slash", "operator": "equal",          "operand": true,              "match_all": true },
+      { "key": "setting.docblockr.extend_double_slash", "operator": "equal",       "operand": true,              "match_all": true },
       { "key": "selector",                           "operator": "equal",          "operand": "comment.line",    "match_all": true },
       { "key": "auto_complete_visible",              "operator": "equal",          "operand": false,             "match_all": true },
       { "key": "preceding_text",                     "operator": "regex_contains", "operand": "^\\s*(\\/\\/[\\/!]?|#)", "match_all": true }
@@ -89,7 +89,7 @@
   { "keys": ["keypad_enter"], "command": "insert_snippet", "args": {"contents": "\n${TM_CURRENT_LINE/^\\s*((?:#|\\/\\/[\\/!]?)\\s*).*$/$1/}"},
     "context": [
       { "key": "setting.auto_indent",                "operator": "equal",          "operand": true,           "match_all": true },
-      { "key": "setting.jsdocs_extend_double_slash", "operator": "equal",          "operand": true,           "match_all": true },
+      { "key": "setting.docblockr.extend_double_slash", "operator": "equal",       "operand": true,           "match_all": true },
       { "key": "selector",                           "operator": "equal",          "operand": "comment.line", "match_all": true },
       { "key": "auto_complete_visible",              "operator": "equal",          "operand": false,          "match_all": true },
       { "key": "preceding_text",                     "operator": "regex_contains", "operand": "^\\s*\\/\\/[\\/!]?",  "match_all": true }
@@ -150,7 +150,7 @@
       { "key": "selection_empty",                  "operator": "equal",          "operand": true,              "match_all": true },
       { "key": "auto_complete_visible",            "operator": "equal",          "operand": false,             "match_all": true },
       { "key": "preceding_text",                   "operator": "regex_contains", "operand": "^\\s*\\/\\*{2}$", "match_all": true },
-      { "key": "setting.jsdocs_quick_open_inline", "operator": "equal",          "operand": true,              "match_all": true}
+      { "key": "setting.docblockr.quick_open_inline", "operator": "equal",       "operand": true,              "match_all": true}
     ]
   },
   // Open an inline docblock (/** */)
@@ -191,7 +191,7 @@
   // indent to align with the previous line
   { "keys": ["tab"], "command": "jsdocs_indent",
     "context": [
-      { "key": "setting.jsdocs_deep_indent", "operator": "equal",          "operand": true,            "match_all": true },
+      { "key": "setting.docblockr.deep_indent", "operator": "equal",       "operand": true,            "match_all": true },
       { "key": "setting.auto_indent",        "operator": "equal",          "operand": true,            "match_all": true },
       { "key": "selection_empty",            "operator": "equal",          "operand": true,            "match_all": true },
       { "key": "preceding_text",             "operator": "regex_contains", "operand": "^\\s*\\*\\s*$", "match_all": true },
@@ -201,14 +201,14 @@
   // decorate a double-slash comment
   { "keys": ["ctrl+enter"], "command": "jsdocs_decorate",
     "context": [
-      { "key": "setting.jsdocs_decorate", "operator": "equal", "operand": true, "match_all": true },
+      { "key": "setting.docblockr.decorate", "operator": "equal", "operand": true, "match_all": true },
       { "key": "selector",                "operator": "equal", "operand": "comment.line.double-slash", "match_all": true }
     ]
   },
   // decorate a double-slash comment
   { "keys": ["ctrl+keypad_enter"], "command": "jsdocs_decorate",
     "context": [
-      { "key": "setting.jsdocs_decorate", "operator": "equal", "operand": true, "match_all": true },
+      { "key": "setting.docblockr.decorate", "operator": "equal", "operand": true, "match_all": true },
       { "key": "selector",                "operator": "equal", "operand": "comment.line.double-slash", "match_all": true }
     ]
   },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -25,14 +25,14 @@
                                 "caption": "Settings – Default",
                                 "command": "open_file", "args":
                                 {
-                                    "file": "${packages}/DocBlockr/Base File.sublime-settings"
+                                    "file": "${packages}/DocBlockr/Preferences.sublime-settings"
                                 }
                             },
                             {
                                 "caption": "Settings – User",
                                 "command": "open_file", "args":
                                 {
-                                    "file": "${packages}/User/Base File.sublime-settings"
+                                    "file": "${packages}/User/Preferences.sublime-settings"
                                 }
                             },
                             {

--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -2,14 +2,14 @@
   // If true, when in a docblock, pressing tab after a @tag line (like @param, @return)
   // will indent to the description. This is useful if you are writing a long description
   // and want that block of text to stay aligned.
-  "jsdocs_deep_indent": true,
+  "docblockr.deep_indent": true,
 
   // If true, then pressing enter while in a double-slash comment (like this one)
   // will automatically add two slashes to the next line as well
-  "jsdocs_extend_double_slash": true,
+  "docblockr.extend_double_slash": true,
 
   // the number of spaces to add after the leading *
-  "jsdocs_indentation_spaces": 1,
+  "docblockr.indentation_spaces": 1,
 
   // The number of spaces to add after the leading * in lines under the first line of each
   // paragraph. This is only used together with automatic line wrapping. For example, a value
@@ -24,7 +24,7 @@
   //  *   massa, sit amet adipiscing dolor.
   //  * @return {[Type]}
   //  */
-  "jsdocs_indentation_spaces_same_para": 1,
+  "docblockr.indentation_spaces_same_para": 1,
 
   // whether the words following the @tags should align.
   // Possible values are 'no', 'shallow', 'deep'
@@ -39,34 +39,34 @@
   // @param    {MyCustomClass} myVariable desc1
   // @return   {String}        foo        desc2
   // @property {Number}        blahblah   desc3
-  "jsdocs_align_tags": "deep",
+  "docblockr.align_tags": "deep",
 
   // Any additional boilerplate tags which should be added to each block. Should be an array of strings.
   // Note that this only applies when a docblock is opened directly preceding a function.
   // Tab points can be added by using snippet syntax, eg: ${1:default text}
-  "jsdocs_extra_tags": [],
+  "docblockr.extra_tags": [],
 
   // If extra tags are defined, by default they go between the description and the param/return tags. If this is set to
   // true, the extra tags are placed at the very end.
-  "jsdocs_extra_tags_go_after": false,
+  "docblockr.extra_tags_go_after": false,
 
   // A map to determine the value of variables, should hungarian notation (or similar) be in use
-  "jsdocs_notation_map": [],
+  "docblockr.notation_map": [],
 
   // Since there seems to be no agreed standard for "@return" or "@returns", use this setting to rename it as you wish.
-  "jsdocs_return_tag": "@return",
+  "docblockr.return_tag": "@return",
 
   // Add a '[function_name description]' for the function block
-  "jsdocs_function_description": true,
+  "docblockr.function_description": true,
 
   // Add a '[description]' placeholder for the return tag?
-  "jsdocs_return_description": true,
+  "docblockr.return_description": true,
 
   // Add a '[description]' placeholder for the param tag?
-  "jsdocs_param_description": true,
+  "docblockr.param_description": true,
 
   // Add a name of parameter in param tag?
-  "jsdocs_param_name": true,
+  "docblockr.param_name": true,
 
   // Whether there should be blank lines added between the description line, and between tags of different types.
   // Possible values are true, false, or "after_description".
@@ -91,11 +91,11 @@
   //  * @param  {Number} bar
   //  * @return {[Type]}
   //  */
-  "jsdocs_spacer_between_sections": false,
+  "docblockr.spacer_between_sections": false,
 
   // Whether each section should be indented to the same level, or indent each one individually.
   // (When true, the @param section will lose the extra space immediately after each '@param').
-  "jsdocs_per_section_indent": false,
+  "docblockr.per_section_indent": false,
 
   // Minimum spaces between cols (default is 1). For example, a value
   // of 2 might look like this:
@@ -108,32 +108,32 @@
   //  *
   //  * @return  {[Type]}       description
   //  */
-  "jsdocs_min_spaces_between_columns": 1,
+  "docblockr.min_spaces_between_columns": 1,
 
   // indicates whether the @method tag should be added automatically
-  "jsdocs_autoadd_method_tag": false,
+  "docblockr.autoadd_method_tag": false,
 
   // If set to true, DocBlockr won't parse any code, providing no default templates. All other functions work as normal.
-  "jsdocs_simple_mode": false,
+  "docblockr.simple_mode": false,
 
   // If set to true, primitives such as "Number" and "String" will be documented as "number" and "string".
-  "jsdocs_lower_case_primitives": false,
+  "docblockr.lower_case_primitives": false,
 
   // If set to true, primitives such as "boolean" and "integer" will be shortened to "bool" and "int".
-  "jsdocs_short_primitives": false,
+  "docblockr.short_primitives": false,
 
   // This property affects the default tag added to `var` declarations in Javascript/Coffeescript. If `false`, the
   // default is used ("var"), otherwise it can be set to any String, eg: "property"
-  "jsdocs_override_js_var": false,
+  "docblockr.override_js_var": false,
 
   // If set to true, an extra line break is added after the end of a docblock to separate it from the code.
-  "jsdocs_newline_after_block": false,
+  "docblockr.newline_after_block": false,
 
   // If set to true, Ctrl+Enter while in a single line comment will 'decorate' the comment.
-  "jsdocs_decorate": true,
+  "docblockr.decorate": true,
 
   // If set to true, typing /**<space> will open an inline docblock
-  "jsdocs_quick_open_inline": true,
+  "docblockr.quick_open_inline": true,
 
-  "jsdocs_development_mode": false
+  "docblockr.development_mode": false
 }

--- a/README.md
+++ b/README.md
@@ -24,27 +24,7 @@ the pull request back to that branch.
 
 ## Changelog
 
-- **v2.14.1**, *17 Aug 2015*
-  - Fix deindentation bug with reparsing doc blocks
-- **v2.14.0**, *15 Jun 2015*
-  - Adds `jsdocs_function_description` option (thanks to [Gerard Roche](https://github.com/gerardroche))
-  - Better handling of parser errors (thanks to Gerard Roche)
-- **v2.13.3**, *4 Jun 2015*
-  - PHP array shorthand is identified correctly (thanks to [Gerard Roche](https://github.com/gerardroche))
-  - Decorating comments when using tabs for indentation works better (thanks to [Jack Cherng](https://github.com/jfcherng))
-- **v2.13.2**, *30 Mar 2015*
-  - Updated PHPDoc autocompletions to align with the new spec (thanks to [Gerard Roche](https://github.com/gerardroche))
-  - Properly handle the case when commas appear inside a type name in Java
-  - Added link to README in the preferences menu
-- **v2.13.1**, *29 Mar 2015*
-  - Adds support for Apex language (thanks @michacom)
-  - Fixes identifying multidimensional arrays in C/C++
-  - Fixes reformatting and reparsing docblocks in Java
-  - Adds options to disable:
-    - opening an inline docblock with space (`jsdocs_quick_open_inline`)
-    - inline comment decoration (`jsdocs_decorate`)
-
-Older history can be found in [the history file][history].
+See [the history file][history].
 
 ## Usage
 
@@ -100,7 +80,7 @@ DocBlockr will also try to determine the type of the variable from its name. Var
 
 ```js
 {
-    "jsdocs_notation_map": [
+    "docblockr.notation_map": [
         {
             "prefix": "b", /* a prefix, matches only if followed by an underscore or A-Z */
             "type": "bool" /* translates to "Boolean" in javascript, "bool" in PHP */
@@ -152,7 +132,7 @@ If you write a double-slash comment and then press `Ctrl+Enter`, DocBlockr will 
     // Foo bar baz //
     /////////////////
 
-This can be disabled by changing the `jsdocs_decorate` setting to `false`.
+This can be disabled by changing the `docblockr.decorate` setting to `false`.
 
 ### Reparsing a DocBlock
 
@@ -182,21 +162,19 @@ Finally, typing `@` inside a docblock will show a completion list for all tags s
 
 You can access the configuration settings by selecting `Preferences -> Package Settings -> DocBlockr`.
 
-*The `jsdocs_*` prefix is a legacy from days gone by...*
+- `docblockr.indentation_spaces` *(Number)* The number of spaces to indent after the leading asterisk.
 
-- `jsdocs_indentation_spaces` *(Number)* The number of spaces to indent after the leading asterisk.
-
-        // jsdocs_indentation_spaces = 1
+        // docblockr.indentation_spaces = 1
         /**
          * foo
          */
 
-        // jsdocs_indentation_spaces = 5
+        // docblockr.indentation_spaces = 5
         /**
          *     foo
          */
 
-- `jsdocs_align_tags` *(String)* Whether the words following the tags should align. Possible values are `'no'`, `'shallow'` and `'deep'`
+- `docblockr.align_tags` *(String)* Whether the words following the tags should align. Possible values are `'no'`, `'shallow'` and `'deep'`
 
     > For backwards compatibility, `false` is equivalent to `'no'`, `true` is equivalent to `'shallow'`
 
@@ -213,9 +191,9 @@ You can access the configuration settings by selecting `Preferences -> Package S
         @property {Number}        blahblah   desc3
 
 
-- `jsdocs_extra_tags` *(Array.String)* An array of strings, each representing extra boilerplate comments to add to *functions*. These can also include arbitrary text (not just tags).
+- `docblockr.extra_tags` *(Array.String)* An array of strings, each representing extra boilerplate comments to add to *functions*. These can also include arbitrary text (not just tags).
 
-        // jsdocs_extra_tags = ['This is a cool function', '@author nickf', '@version ${1:[version]}']
+        // docblockr.extra_tags = ['This is a cool function', '@author nickf', '@version ${1:[version]}']
         /**<<enter>>
         function foo (x) {}
 
@@ -231,7 +209,7 @@ You can access the configuration settings by selecting `Preferences -> Package S
 
     Basic variable substitution is supported here for the variables `date` and `datetime`, wrapped in double curly brackets.
 
-        // jsdocs_extra_tags = ['@date {{date}}', '@anotherdate {{datetime}}']
+        // docblockr.extra_tags = ['@date {{date}}', '@anotherdate {{datetime}}']
         /**<<enter>>
         function foo() {}
 
@@ -242,37 +220,37 @@ You can access the configuration settings by selecting `Preferences -> Package S
          * @return   {[type]}
          */
 
-- `jsdocs_extra_tags_go_after` *(Boolean)* If true, the extra tags are placed at the end of the block (after param/return). Default: `false`
+- `docblockr.extra_tags_go_after` *(Boolean)* If true, the extra tags are placed at the end of the block (after param/return). Default: `false`
 
-- `jsdocs_extend_double_slash` *(Boolean)* Whether double-slash comments should be extended. An example of this feature is described above. Default: `true`
+- `docblockr.extend_double_slash` *(Boolean)* Whether double-slash comments should be extended. An example of this feature is described above. Default: `true`
 
-- `jsdocs_deep_indent` *(Boolean)* Whether pressing tab at the start of a line in docblock should indent to match the previous line's description field. An example of this feature is described above. Default: `true`
+- `docblockr.deep_indent` *(Boolean)* Whether pressing tab at the start of a line in docblock should indent to match the previous line's description field. An example of this feature is described above. Default: `true`
 
-- `jsdocs_notation_map` *(Array)* An array of notation objects. Each notation object must define either a `prefix` OR a `regex` property, and a `type` property.
+- `docblockr.notation_map` *(Array)* An array of notation objects. Each notation object must define either a `prefix` OR a `regex` property, and a `type` property.
 
-- `jsdocs_return_tag` *(String)* The text which should be used for a `@return` tag. By default, `@return` is used, however this can be changed to `@returns` if you use that style.
+- `docblockr.return_tag` *(String)* The text which should be used for a `@return` tag. By default, `@return` is used, however this can be changed to `@returns` if you use that style.
 
-- `jsdocs_spacer_between_sections` *(Boolean|String)* If true, then extra blank lines are inserted between the sections of the docblock. If set to `"after_description"` then a spacer will only be added between the description and the first tag. Default: `false`.
+- `docblockr.spacer_between_sections` *(Boolean|String)* If true, then extra blank lines are inserted between the sections of the docblock. If set to `"after_description"` then a spacer will only be added between the description and the first tag. Default: `false`.
 
-- `jsdocs_indentation_spaces_same_para` *(Number)* Described above in the *Reformatting paragraphs* section. Default: `1`
+- `docblockr.indentation_spaces_same_para` *(Number)* Described above in the *Reformatting paragraphs* section. Default: `1`
 
-- `jsdocs_autoadd_method_tag` *(Boolean)* Add a `@method` tag to docblocks of functions. Default: `false`
+- `docblockr.autoadd_method_tag` *(Boolean)* Add a `@method` tag to docblocks of functions. Default: `false`
 
-- `jsdocs_simple_mode` *(Boolean)* If true, DocBlockr won't add a template when creating a doc block before a function or variable. Useful if you don't want to write Javadoc-style, but still want your editor to help when writing block comments. Default: `false`
+- `docblockr.simple_mode` *(Boolean)* If true, DocBlockr won't add a template when creating a doc block before a function or variable. Useful if you don't want to write Javadoc-style, but still want your editor to help when writing block comments. Default: `false`
 
-- `jsdocs_lower_case_primitives` *(Boolean)* If true, primitive data types are added in lower case, eg "number" instead of "Number". Default: `false`
+- `docblockr.lower_case_primitives` *(Boolean)* If true, primitive data types are added in lower case, eg "number" instead of "Number". Default: `false`
 
-- `jsdocs_short_primitives` *(Boolean)* If true, the primitives `Boolean` and `Integer` are shortened to `Bool` and `Int`. Default: `false`
+- `docblockr.short_primitives` *(Boolean)* If true, the primitives `Boolean` and `Integer` are shortened to `Bool` and `Int`. Default: `false`
 
-- `jsdocs_newline_after_block` *(Boolean)* If true, an extra line break is added after the end of a docblock to separate it from the code. Default `false`
+- `docblockr.newline_after_block` *(Boolean)* If true, an extra line break is added after the end of a docblock to separate it from the code. Default `false`
 
-- `jsdocs_param_name` *(Boolean)* If true, the name of a function parameter is added to the template. If false, it is omitted. Default: `true`
+- `docblockr.param_name` *(Boolean)* If true, the name of a function parameter is added to the template. If false, it is omitted. Default: `true`
 
-- `jsdocs_decorate` *(Boolean)* If false, disable decoration of single line comments with <kbd>Ctrl+Enter</kbd>. Default: `true`
+- `docblockr.decorate` *(Boolean)* If false, disable decoration of single line comments with <kbd>Ctrl+Enter</kbd>. Default: `true`
 
-- `jsdocs_quick_open_inline` *(Boolean)* If true, an inline docblock will be opened when pressing <kbd>Space</kbd> after an opener (`/**`). When set to `false`, these can be opened by pressing <kbd>Shift+Enter</kbd>. Default: `true`
+- `docblockr.quick_open_inline` *(Boolean)* If true, an inline docblock will be opened when pressing <kbd>Space</kbd> after an opener (`/**`). When set to `false`, these can be opened by pressing <kbd>Shift+Enter</kbd>. Default: `true`
 
-- `jsdocs_function_description` *(Boolean)* If true, a 'description' line will be added for functions. Default: `true`
+- `docblockr.function_description` *(Boolean)* If true, a 'description' line will be added for functions. Default: `true`
 
 ## Contributors
 

--- a/test_runner.py
+++ b/test_runner.py
@@ -23,13 +23,13 @@ class ViewTestCase(unittest.TestCase):
         # TODO there's probably a better way to initialise the testcase default settings
         settings = self.view.settings()
         settings.set('auto_indent', False)
-        settings.set('jsdocs_lower_case_primitives', False)
-        settings.set('jsdocs_param_description', True)
-        settings.set('jsdocs_per_section_indent', False)
-        settings.set('jsdocs_return_description', True)
-        settings.set('jsdocs_short_primitives', False)
-        settings.set('jsdocs_spacer_between_sections', False)
-        settings.set('jsdocs_function_description', True)
+        settings.set('docblockr.lower_case_primitives', False)
+        settings.set('docblockr.param_description', True)
+        settings.set('docblockr.per_section_indent', False)
+        settings.set('docblockr.return_description', True)
+        settings.set('docblockr.short_primitives', False)
+        settings.set('docblockr.spacer_between_sections', False)
+        settings.set('docblockr.function_description', True)
 
         if int(sublime.version()) < 3000:
             self.edit = self.view.begin_edit()
@@ -114,7 +114,7 @@ class TestJavaScript(ViewTestCase):
 
     def test_parameters_are_added_to_function_template_with_description_disabled(self):
         self.set_view_content('/**|\nfunction foo (bar, baz) {')
-        self.view.settings().set('jsdocs_function_description', False)
+        self.view.settings().set('docblockr.function_description', False)
         self.run_doc_blockr()
         self.assertDocBlockrResult([
             '/**',
@@ -127,8 +127,8 @@ class TestJavaScript(ViewTestCase):
 
     def test_parameters_are_added_to_function_template_with_description_disabled_and_spacers_between_sections(self):
         self.set_view_content('/**|\nfunction foo (bar, baz) {')
-        self.view.settings().set('jsdocs_function_description', False)
-        self.view.settings().set('jsdocs_spacer_between_sections', True)
+        self.view.settings().set('docblockr.function_description', False)
+        self.view.settings().set('docblockr.spacer_between_sections', True)
         self.run_doc_blockr()
         self.assertDocBlockrResult([
             '/**',
@@ -142,8 +142,8 @@ class TestJavaScript(ViewTestCase):
 
     def test_parameters_are_added_to_function_template_with_description_disabled_and_spacer_after_description_isset(self):
         self.set_view_content('/**|\nfunction foo (bar, baz) {')
-        self.view.settings().set('jsdocs_function_description', False)
-        self.view.settings().set('jsdocs_spacer_between_sections', 'after_description')
+        self.view.settings().set('docblockr.function_description', False)
+        self.view.settings().set('docblockr.spacer_between_sections', 'after_description')
         self.run_doc_blockr()
         self.assertDocBlockrResult([
             '/**',
@@ -237,7 +237,7 @@ class TestPHP(ViewTestCase):
 
     def get_syntax_file(self):
         # Allows overriding with custom syntax
-        php_syntax_file = self.view.settings().get('doc_blockr_tests_php_syntax_file')
+        php_syntax_file = self.view.settings().get('docblockr.tests_php_syntax_file')
         if not php_syntax_file:
             return 'Packages/PHP/PHP.tmLanguage'
         else:
@@ -374,7 +374,7 @@ class TestPHP(ViewTestCase):
 
     def test_optional_function_description(self):
         self.set_view_content("<?php\n/**|\nfunction fname($a) {}")
-        self.view.settings().set('jsdocs_function_description', False)
+        self.view.settings().set('docblockr.function_description', False)
         self.run_doc_blockr()
         self.assertDocBlockrResult([
             "<?php",
@@ -387,8 +387,8 @@ class TestPHP(ViewTestCase):
 
     def test_optional_function_description_with_spacers_between_sections(self):
         self.set_view_content("<?php\n/**|\nfunction fname($a) {}")
-        self.view.settings().set('jsdocs_function_description', False)
-        self.view.settings().set('jsdocs_spacer_between_sections', True)
+        self.view.settings().set('docblockr.function_description', False)
+        self.view.settings().set('docblockr.spacer_between_sections', True)
         self.run_doc_blockr()
         self.assertDocBlockrResult([
             "<?php",
@@ -402,8 +402,8 @@ class TestPHP(ViewTestCase):
 
     def test_optional_function_description_with_spacer_after_description_set_to_true(self):
         self.set_view_content("<?php\n/**|\nfunction fname($a) {}")
-        self.view.settings().set('jsdocs_function_description', False)
-        self.view.settings().set('jsdocs_spacer_between_sections', 'after_description')
+        self.view.settings().set('docblockr.function_description', False)
+        self.view.settings().set('docblockr.spacer_between_sections', 'after_description')
         self.run_doc_blockr()
         self.assertDocBlockrResult([
             "<?php",

--- a/tests/Default.sublime-keymap
+++ b/tests/Default.sublime-keymap
@@ -1,10 +1,10 @@
 [
-    // run tests. requires jsdocs_development_mode to be on
+    // run tests. requires docblockr.development_mode to be on
     {
       "keys": ["ctrl+k", "ctrl+t"],
       "command": "run_doc_blockr_tests",
       "context": [
-        { "key": "setting.jsdocs_development_mode", "operator": "equal", "operand": true }
+        { "key": "setting.docblockr.development_mode", "operator": "equal", "operand": true }
       ]
     }
 ]


### PR DESCRIPTION
For the most part this is backwards compatible, though there are some edge-case bc breakages. 
- Fixes #313
- Fixes #334
- Fixes #338
- Fixes #408
- Fixes #400
- Fixes #360
- Fixes #397 
## What does it change?
1. Setting prefix is renamed from `jsdocs_*` to `docblockr.*`.
2. Settings are now stored in `User/Preferences.sublime-settings` instead of `User/Base File.sublime-settings`.

The trickiest part is making sure the refactor is backwards compatible. See [here](https://github.com/spadgos/sublime-jsdocs/compare/develop...gerardroche:refactor-settings?expand=1#diff-61b0eb45196bdca3aa95ada6717507c3R19) for relevant settings migration code.

Is this something that will be accepted to merge? 

I'm happy to address any issues to get this change merged.
